### PR TITLE
fix: strip component path fields from vendor plugin.json

### DIFF
--- a/packages/add-plugin/lib/install.ts
+++ b/packages/add-plugin/lib/install.ts
@@ -228,6 +228,27 @@ async function preparePluginDirForVendor(
 
   if (hasOpenPlugin && !hasVendorPlugin) {
     await cp(openPluginDir, vendorPluginDir, { recursive: true });
+
+    // Strip open-plugin component path fields that vendor validators may reject.
+    // Vendors discover skills/commands/agents/rules from the filesystem; these
+    // path overrides are only meaningful to the open-plugin spec.
+    const vendorManifestPath = join(vendorPluginDir, "plugin.json");
+    if (existsSync(vendorManifestPath)) {
+      const raw = await readFile(vendorManifestPath, "utf-8");
+      const manifest = JSON.parse(raw);
+      const componentFields = ["skills", "commands", "agents", "rules", "hooks", "mcpServers", "lspServers", "outputStyles"];
+      let stripped = false;
+      for (const field of componentFields) {
+        if (field in manifest) {
+          delete manifest[field];
+          stripped = true;
+        }
+      }
+      if (stripped) {
+        await writeFile(vendorManifestPath, JSON.stringify(manifest, null, 2));
+      }
+    }
+
     console.log(`  ${plugin.name}: translated .plugin/ -> ${vendorDir}/`);
   }
 


### PR DESCRIPTION
## Summary

- When `preparePluginDirForVendor` copies `.plugin/plugin.json` → `.claude-plugin/plugin.json`, open-plugin spec fields (`skills`, `commands`, `agents`, `rules`, `hooks`, `mcpServers`, `lspServers`, `outputStyles`) were passed through verbatim
- Claude Code's internal plugin validator rejects these fields, causing installation to fail with: `Validation errors: commands: Invalid input, agents: Invalid input, skills: Invalid input`
- After copying, strip these component path fields since vendors discover components from the filesystem automatically

## Test plan

- [x] Verified `add-plugin https://github.com/vercel-labs/vercel-plugin -s project` now installs successfully (was failing before)
- [ ] Verify Cursor installation still works with the stripped manifest
- [ ] Verify plugins without component path fields in plugin.json are unaffected