### PR TITLE
Prepare the canonical production deployment

### DIFF
--- a/app/[lang]/(docs)/[[...slug]]/page.tsx
+++ b/app/[lang]/(docs)/[[...slug]]/page.tsx
@@ -72,16 +72,35 @@ export const generateMetadata = async ({
     notFound();
   }
 
+  const title = page.data.title;
+  const description = page.data.description;
+  const image = {
+    alt: title,
+    url: getPageImage(page).url,
+  };
+
   const metadata: Metadata = {
-    title: page.data.title,
-    description: page.data.description,
-    openGraph: {
-      images: getPageImage(page).url,
-    },
+    title: page.url === "/" ? { absolute: title } : title,
+    description,
     alternates: {
+      canonical: page.url,
       types: {
-        "text/markdown": slug ? `/docs/${slug}.md` : "/docs.md",
+        "text/markdown": page.url === "/" ? "/docs.md" : `${page.url}.md`,
       },
+    },
+    openGraph: {
+      type: "website",
+      url: page.url,
+      siteName: "Agent Plugins",
+      title,
+      description,
+      images: [image],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [image],
     },
   };
 

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -2,9 +2,22 @@ import "../global.css";
 import { Footer } from "@/components/geistdocs/footer";
 import { Navbar } from "@/components/geistdocs/navbar";
 import { GeistdocsProvider } from "@/components/geistdocs/provider";
-import { basePath } from "@/geistdocs";
+import { basePath, siteUrl } from "@/geistdocs";
 import { mono, sans } from "@/lib/geistdocs/fonts";
 import { cn } from "@/lib/utils";
+import type { Metadata } from "next";
+
+const description =
+  "A portable package format for reusable components that extend AI agents.";
+
+export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: "Agent Plugins",
+    template: "%s | Agent Plugins",
+  },
+  description,
+};
 
 const Layout = async ({ children, params }: LayoutProps<"/[lang]">) => {
   const { lang } = await params;

--- a/app/[lang]/rss.xml/route.ts
+++ b/app/[lang]/rss.xml/route.ts
@@ -1,10 +1,7 @@
 import { Feed } from "feed";
 import type { NextRequest } from "next/server";
-import { title } from "@/geistdocs";
+import { siteUrl, title } from "@/geistdocs";
 import { source } from "@/lib/geistdocs/source";
-
-const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-const baseUrl = `${protocol}://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`;
 
 export const revalidate = false;
 
@@ -15,8 +12,8 @@ export const GET = async (
   const { lang } = await params;
   const feed = new Feed({
     title,
-    id: baseUrl,
-    link: baseUrl,
+    id: siteUrl,
+    link: siteUrl,
     language: lang,
     copyright: `Agent Plugins documentation contributors, ${new Date().getFullYear()}. CC BY 4.0.`,
   });
@@ -26,7 +23,7 @@ export const GET = async (
       id: page.url,
       title: page.data.title,
       description: page.data.description,
-      link: `${baseUrl}${page.url}`,
+      link: new URL(page.url, siteUrl).toString(),
       date: new Date(page.data.lastModified ?? new Date()),
       author: [
         {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,6 @@
 import type { MetadataRoute } from "next";
 
-const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-const baseUrl = `${protocol}://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`;
+import { siteUrl } from "@/geistdocs";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -9,6 +8,6 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: `${baseUrl}/sitemap.xml`,
+    sitemap: `${siteUrl}/sitemap.xml`,
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,34 +1,19 @@
 import type { MetadataRoute } from "next";
 
+import { siteUrl } from "@/geistdocs";
 import { source } from "@/lib/geistdocs/source";
-
-const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-const baseUrl = `${protocol}://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`;
 
 export const revalidate = false;
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const url = (path: string): string => new URL(path, baseUrl).toString();
+  const url = (path: string): string => new URL(path, siteUrl).toString();
 
-  const pages: MetadataRoute.Sitemap = [];
-
-  for (const page of source.getPages()) {
-    pages.push({
-      changeFrequency: "weekly" as const,
-      lastModified: page.data.lastModified
-        ? new Date(page.data.lastModified)
-        : undefined,
-      priority: 0.5,
-      url: url(page.url),
-    });
-  }
-
-  return [
-    {
-      changeFrequency: "monthly",
-      priority: 1,
-      url: url("/"),
-    },
-    ...pages,
-  ];
+  return source.getPages().map((page) => ({
+    changeFrequency: page.url === "/" ? "monthly" : "weekly",
+    lastModified: page.data.lastModified
+      ? new Date(page.data.lastModified)
+      : undefined,
+    priority: page.url === "/" ? 1 : 0.5,
+    url: url(page.url),
+  }));
 }

--- a/components/geistdocs/ask-ai.tsx
+++ b/components/geistdocs/ask-ai.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { MessageCircleIcon } from "lucide-react";
+import { siteUrl } from "@/geistdocs";
 import { useChatContext } from "@/hooks/geistdocs/use-chat";
 
 interface AskAIProps {
@@ -10,11 +11,7 @@ interface AskAIProps {
 export const AskAI = ({ href }: AskAIProps) => {
   const { setIsOpen, setPrompt } = useChatContext();
 
-  const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-  const url = new URL(
-    href,
-    `${protocol}://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`
-  ).toString();
+  const url = new URL(href, siteUrl).toString();
   const query = `Read this page, I want to ask questions about it. ${url}`;
 
   return (

--- a/components/geistdocs/open-in-chat.tsx
+++ b/components/geistdocs/open-in-chat.tsx
@@ -11,17 +11,14 @@ import {
   OpenInTrigger,
   OpenInv0,
 } from "@/components/ai-elements/open-in-chat";
+import { siteUrl } from "@/geistdocs";
 
 interface OpenInChatProps {
   href: string;
 }
 
 export const OpenInChat = ({ href }: OpenInChatProps) => {
-  const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-  const url = new URL(
-    href,
-    `${protocol}://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`
-  ).toString();
+  const url = new URL(href, siteUrl).toString();
   const query = `Read this page, I want to ask questions about it. ${url}`;
 
   return (

--- a/geistdocs.tsx
+++ b/geistdocs.tsx
@@ -23,6 +23,8 @@ export const suggestions = [
 
 export const title = "Agent Plugins Documentation";
 
+export const siteUrl = "https://agent-plugins.org";
+
 export const translations = {
   en: {
     displayName: "English",

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,18 @@ import type { NextConfig } from "next";
 
 const withMDX = createMDX();
 
+const publishedSchemaPaths = [
+  "/schemas/1.0.0/plugin.schema.json",
+  "/schemas/1.0.0/mcp.schema.json",
+] as const;
+
+const immutableSchemaHeaders = [
+  {
+    key: "Cache-Control",
+    value: "public, max-age=31536000, immutable",
+  },
+];
+
 const redirectHosts = [
   "open-plugins.com",
   "www.open-plugins.com",
@@ -47,6 +59,13 @@ const config: NextConfig = {
 
   images: {
     formats: ["image/avif", "image/webp"],
+  },
+
+  async headers() {
+    return publishedSchemaPaths.map((source) => ({
+      source,
+      headers: immutableSchemaHeaders,
+    }));
   },
 
   async redirects() {

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,43 @@ import type { NextConfig } from "next";
 
 const withMDX = createMDX();
 
+const redirectHosts = [
+  "open-plugins.com",
+  "www.open-plugins.com",
+  "agent-plugins.io",
+  "www.agent-plugins.io",
+  "www.agent-plugins.org",
+] as const;
+
+const escapeRegex = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// `has.value` is a regular expression. Group the complete alternation because
+// Next.js anchors the value when it compiles the host condition.
+const redirectHostPattern = `(?:${redirectHosts.map(escapeRegex).join("|")})`;
+
+const legacyPageMapping = [
+  ["/agent-builders", "/client-implementers"],
+  [
+    "/agent-builders/components/mcp-servers",
+    "/client-implementers/mcp-runtime",
+  ],
+  ["/agent-builders/components/skills", "/plugin-authors/skills"],
+  ["/plugin-builders", "/plugin-authors"],
+  ["/plugin-builders/installation", "/plugin-authors"],
+  ["/plugin-builders/specification", "/specification"],
+  ["/supported-agents", "/client-implementers"],
+] as const;
+
+const legacyPageRedirects = legacyPageMapping.flatMap(([source, destination]) => [
+  { source, destination, permanent: true as const },
+  {
+    source: `${source}.:extension(md|mdx)`,
+    destination: `${destination}.:extension`,
+    permanent: true as const,
+  },
+]);
+
 const config: NextConfig = {
   experimental: {
     turbopackFileSystemCacheForDev: true,
@@ -10,6 +47,41 @@ const config: NextConfig = {
 
   images: {
     formats: ["image/avif", "image/webp"],
+  },
+
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: redirectHostPattern }],
+        destination: "https://agent-plugins.org/:path*",
+        permanent: true,
+      },
+      ...legacyPageRedirects,
+      {
+        source:
+          "/agent-builders/components/:component(agents|hooks|lsp-servers|rules)",
+        destination: "/specification#why-only-agent-skills-and-mcp-in-v1",
+        permanent: false,
+      },
+      {
+        source:
+          "/agent-builders/components/:component(agents|hooks|lsp-servers|rules).:extension(md|mdx)",
+        destination:
+          "/specification.:extension#why-only-agent-skills-and-mcp-in-v1",
+        permanent: false,
+      },
+      {
+        source: "/plugin-builders/marketplace",
+        destination: "/",
+        permanent: true,
+      },
+      {
+        source: "/plugin-builders/marketplace.:extension(md|mdx)",
+        destination: "/docs.:extension",
+        permanent: true,
+      },
+    ];
   },
 };
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -64,7 +64,7 @@ const proxy = async (request: NextRequest, context: NextFetchEvent) => {
   ) {
     const stripped = pathname.replace(MDX_EXTENSION_PATTERN, "");
     const result =
-      stripped === "/"
+      stripped === "/" || stripped === "/docs"
         ? `/${i18n.defaultLanguage}/llms.mdx`
         : rewriteLLM(stripped);
     if (result) {


### PR DESCRIPTION
## Summary

- establish `https://agent-plugins.org` as the canonical site URL across page metadata, social cards, AI handoffs, RSS, robots, and the sitemap
- preserve the legacy Open Plugins hosts, the `.io` and `www` variants, and every published HTML, `.md`, and `.mdx` documentation route with permanent redirects
- expose correct canonical and Markdown-alternate links for every documentation page
- serve the two published `1.0.0` JSON schemas with immutable cache headers without applying those headers to unknown or future schema paths

## Why

The rewritten documentation needs stable production metadata and compatibility routes before the public domains are moved to it. Centralizing the canonical URL also prevents environment-selected Vercel aliases from leaking into discovery files and prompts handed to AI providers.

This PR prepares the application for the domain cutover; it does not attach or move any Vercel domains.

## Verification

- `pnpm build`
- started the production build locally and verified all 36 legacy page representations return the intended `308` destination
- verified all five intended host aliases redirect, lookalike hosts do not, and encoded paths and query strings are preserved
- verified only the two published schemas receive `Cache-Control: public, max-age=31536000, immutable`
- verified rendered canonical, Open Graph, Twitter, and `text/markdown` metadata
- verified the sitemap contains the homepage once and generated AI prompts contain the canonical domain
