### PR TITLE
Fix Markdown sitemap and root negotiation

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -41,6 +41,11 @@ const rewriteInternally = (
 
 const proxy = async (request: NextRequest, context: NextFetchEvent) => {
   const pathname = request.nextUrl.pathname;
+  const isSemanticSitemap =
+    pathname === "/sitemap.md" ||
+    i18n.languages.some(
+      (language) => pathname === `/${language}/sitemap.md`,
+    );
 
   // `next start` runs the proxy again for an internal locale rewrite. Let that
   // rewritten request reach the localized App Router route instead of sending
@@ -57,6 +62,7 @@ const proxy = async (request: NextRequest, context: NextFetchEvent) => {
 
   // Handle .md/.mdx URL requests before i18n runs.
   if (
+    !isSemanticSitemap &&
     (pathname === "/docs.md" ||
       pathname === "/docs.mdx" ||
       pathname.startsWith("/")) &&

--- a/proxy.ts
+++ b/proxy.ts
@@ -12,6 +12,11 @@ const { rewrite: rewriteLLM } = rewritePath(
   `/${i18n.defaultLanguage}/llms.mdx/*path`,
 );
 
+const rewriteMarkdownPath = (pathname: string) =>
+  pathname === "/" || pathname === "/docs"
+    ? `/${i18n.defaultLanguage}/llms.mdx`
+    : rewriteLLM(pathname);
+
 const MDX_EXTENSION_PATTERN = /\.mdx?$/;
 const INTERNAL_I18N_REWRITE_HEADER = "x-agent-plugins-i18n-rewrite";
 
@@ -69,10 +74,7 @@ const proxy = async (request: NextRequest, context: NextFetchEvent) => {
     (pathname.endsWith(".md") || pathname.endsWith(".mdx"))
   ) {
     const stripped = pathname.replace(MDX_EXTENSION_PATTERN, "");
-    const result =
-      stripped === "/" || stripped === "/docs"
-        ? `/${i18n.defaultLanguage}/llms.mdx`
-        : rewriteLLM(stripped);
+    const result = rewriteMarkdownPath(stripped);
     if (result) {
       return rewriteInternally(request, new URL(result, request.nextUrl));
     }
@@ -80,7 +82,7 @@ const proxy = async (request: NextRequest, context: NextFetchEvent) => {
 
   // Handle Accept header content negotiation.
   if (isMarkdownPreferred(request)) {
-    const result = rewriteLLM(pathname);
+    const result = rewriteMarkdownPath(pathname);
     if (result) {
       return rewriteInternally(request, new URL(result, request.nextUrl));
     }

--- a/proxy.ts
+++ b/proxy.ts
@@ -81,7 +81,7 @@ const proxy = async (request: NextRequest, context: NextFetchEvent) => {
   }
 
   // Handle Accept header content negotiation.
-  if (isMarkdownPreferred(request)) {
+  if (!isSemanticSitemap && isMarkdownPreferred(request)) {
     const result = rewriteMarkdownPath(pathname);
     if (result) {
       return rewriteInternally(request, new URL(result, request.nextUrl));


### PR DESCRIPTION
The production proxy treated every `.md` request as a raw documentation page before the App Router could handle semantic routes. As a result, `/sitemap.md` was rewritten to a nonexistent documentation path and returned 404, even though every raw Markdown page linked to it.

The root route also bypassed the special rewrite used by `/docs.md`, so `Accept: text/markdown` returned HTML at `/` while content negotiation worked on every other published page.

This PR contains three signed commits:

1. Exempt the semantic sitemap route, including its locale-prefixed internal form, from the generic raw-document rewrite so the existing App Router route can serve it.
2. Share the root Markdown rewrite between explicit extension URLs and `Accept` negotiation.
3. Keep the semantic sitemap out of the later `Accept` negotiation path as well, so Markdown-preferring clients still reach its dedicated route.

Validated with:

- `pnpm build`
- `/sitemap.md` returns 200 `text/markdown` and lists all 12 published pages for both `Accept: */*` and `Accept: text/markdown`
- `/en/sitemap.md` redirects to `/sitemap.md` with a Markdown-preferred `Accept` header
- all 12 published routes return Markdown byte-identical to their `.md` endpoints for `Accept: text/markdown`
- `/` continues to return HTML for `Accept: */*` and when Markdown has `q=0`
- the complete legacy redirect and 404 control matrix remains unchanged

The release audit identified these route classes for production smoke coverage in the planned CI work.
