### PR TITLE
Polish documentation navigation and chat links

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,6 +23,7 @@ export const metadata: Metadata = {
 const Layout = ({ children }: LayoutProps<"/">) => (
   <html
     className={cn(sans.variable, mono.variable, "scroll-smooth antialiased")}
+    data-scroll-behavior="smooth"
     lang="en"
     suppressHydrationWarning
   >

--- a/components/ai-elements/open-in-chat.tsx
+++ b/components/ai-elements/open-in-chat.tsx
@@ -98,7 +98,7 @@ const providers = {
     createUrl: (prompt: string) =>
       `https://chatgpt.com/?${new URLSearchParams({
         hints: "search",
-        prompt,
+        q: prompt,
       })}`,
     icon: (
       <svg

--- a/components/geistdocs/open-in-chat.tsx
+++ b/components/geistdocs/open-in-chat.tsx
@@ -6,7 +6,6 @@ import {
   OpenInContent,
   OpenInCursor,
   OpenInScira,
-  OpenInSeparator,
   OpenInT3,
   OpenInTrigger,
   OpenInv0,
@@ -33,13 +32,12 @@ export const OpenInChat = ({ href }: OpenInChatProps) => {
         </button>
       </OpenInTrigger>
       <OpenInContent align="start" side="top">
-        <OpenInv0 />
-        <OpenInSeparator />
         <OpenInChatGPT />
         <OpenInClaude />
-        <OpenInT3 />
-        <OpenInScira />
         <OpenInCursor />
+        <OpenInScira />
+        <OpenInT3 />
+        <OpenInv0 />
       </OpenInContent>
     </OpenIn>
   );


### PR DESCRIPTION
## Summary

This PR makes three focused documentation-site fixes, each in its own commit:

- **Fix route transition scroll offset** (`11a4ec2`): declare the root document's smooth-scroll behavior so Next.js can reset SPA navigations immediately, preventing page titles from landing beneath the sticky navbar.
- **Sort chat providers alphabetically** (`2d8adcd`): reorder the existing “Open in chat” entries alphabetically and remove the separator, without changing the shared dropdown implementation.
- **Fix the ChatGPT pre-filled prompt** (`4f02e58`): use ChatGPT's recognized `q` parameter while retaining Search mode, so the prompt is pre-filled without extra quotation marks.

## Validation

- `pnpm build` (production build and TypeScript)
- Verified the root document emits the Next.js smooth-scroll marker and the route-scroll handler performs an immediate reset
- Verified provider composition order: ChatGPT, Claude, Cursor, Scira, T3 Chat, v0
- Verified the generated ChatGPT URL contains the unquoted prompt and ChatGPT recognizes `q` as the instant-prompt parameter

Browser screenshot automation was not available in the local environment; the provided before-state screenshots were used as the visual references.
