### PR TITLE
Clean up machine-readable documentation output

### DIFF
--- a/app/llms.mdx/[[...slug]]/route.ts
+++ b/app/llms.mdx/[[...slug]]/route.ts
@@ -16,7 +16,7 @@ export async function GET(
 
   return new Response(await getLLMText(page), {
     headers: {
-      "Content-Type": "text/markdown",
+      "Content-Type": "text/markdown; charset=utf-8",
     },
   });
 }

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,12 +1,19 @@
-import { getLLMText, source } from "@/lib/geistdocs/source";
+import {
+  getLLMText,
+  LLM_NAVIGATION_FOOTER,
+  source,
+} from "@/lib/geistdocs/source";
 
 export const revalidate = false;
 
 export const GET = async () => {
-  const scan = source.getPages().map(getLLMText);
+  const scan = source
+    .getPages()
+    .map((page) => getLLMText(page, { includeNavigationFooter: false }));
   const scanned = await Promise.all(scan);
+  const content = [...scanned, LLM_NAVIGATION_FOOTER].join("\n\n");
 
-  return new Response(scanned.join("\n\n"), {
+  return new Response(content, {
     headers: {
       "Content-Type": "text/markdown; charset=utf-8",
     },

--- a/app/sitemap.md/route.ts
+++ b/app/sitemap.md/route.ts
@@ -187,7 +187,7 @@ It is not intended to replace individual docs.
 
   return new Response(header + body, {
     headers: {
-      "Content-Type": "text/markdown",
+      "Content-Type": "text/markdown; charset=utf-8",
     },
   });
 };

--- a/content/docs/client-implementers/conformance.mdx
+++ b/content/docs/client-implementers/conformance.mdx
@@ -1,6 +1,7 @@
 ---
 title: Client conformance checklist
 description: Review the minimum behavior required for an Agent Plugins 1.0.0 client.
+type: reference
 ---
 
 This checklist is non-normative. The [complete specification](/specification) governs when wording differs.

--- a/content/docs/schemas.mdx
+++ b/content/docs/schemas.mdx
@@ -1,6 +1,7 @@
 ---
 title: JSON Schemas
 description: Canonical machine-readable schemas for Agent Plugins manifests and MCP configuration.
+type: reference
 ---
 
 Agent Plugins publishes separate JSON Schemas for the plugin manifest and MCP server configuration. Clients use each canonical `$schema` identifier to select locally supported validation and interpretation rules; they do not retrieve schemas while loading a plugin.

--- a/content/docs/specification.mdx
+++ b/content/docs/specification.mdx
@@ -1,6 +1,7 @@
 ---
 title: Agent Plugins Specification
 description: The complete normative contract for portable Agent Plugin packages and conformant clients.
+type: reference
 ---
 
 **Spec Version: 1.0.0**

--- a/lib/geistdocs/source.ts
+++ b/lib/geistdocs/source.ts
@@ -21,7 +21,16 @@ export const getPageImage = (page: InferPageType<typeof source>) => {
   };
 };
 
-export const getLLMText = async (page: InferPageType<typeof source>) => {
+export const LLM_NAVIGATION_FOOTER = `---
+
+For a semantic overview of all documentation, see [/sitemap.md](/sitemap.md)
+
+For an index of all available documentation, see [/llms.txt](/llms.txt)`;
+
+export const getLLMText = async (
+  page: InferPageType<typeof source>,
+  { includeNavigationFooter = true } = {}
+) => {
   const processed = await page.data.getText("processed");
   const { title, description, product, type, summary, prerequisites, related } =
     page.data;
@@ -41,15 +50,15 @@ export const getLLMText = async (page: InferPageType<typeof source>) => {
     .filter(Boolean)
     .join("\n");
 
-  return `${frontmatter}
+  const body = `${frontmatter}
 
 # ${title}
 
-${processed}
+${processed}`;
 
----
+  return includeNavigationFooter
+    ? `${body}
 
-For a semantic overview of all documentation, see [/sitemap.md](/sitemap.md)
-
-For an index of all available documentation, see [/llms.txt](/llms.txt)`;
+${LLM_NAVIGATION_FOOTER}`
+    : body;
 };


### PR DESCRIPTION
## Summary

- classify the specification, schemas, and conformance checklist as reference documentation
- emit the shared navigation footer once in `llms.txt`
- declare UTF-8 on all Markdown responses

## Why

The generated machine-readable documentation contained inaccurate type metadata, repeated navigation text for every concatenated page, and ambiguous character encoding on responses containing Unicode.

## Validation

- `next build`
- rendered endpoint assertions for sitemap types, `llms.txt` footer counts, Markdown content types, and Unicode preservation
