### PR TITLE
Improve documentation navigation accessibility

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,6 +27,12 @@ const Layout = ({ children }: LayoutProps<"/">) => (
     suppressHydrationWarning
   >
     <body>
+      <a
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:shadow"
+        href="#nd-page"
+      >
+        Skip to content
+      </a>
       <GeistdocsProvider basePath={basePath}>
         <SidebarProvider>
           <Navbar />

--- a/components/geistdocs/code-block.tsx
+++ b/components/geistdocs/code-block.tsx
@@ -89,6 +89,7 @@ export const CodeBlock = ({
           className={cn(lineNumbers ? "line-numbers" : "", className)}
         />
         <Button
+          aria-label="Copy code"
           className="absolute top-[5px] right-[5px] bg-background/80 backdrop-blur-sm"
           onClick={copyToClipboard}
           size="icon"
@@ -112,6 +113,7 @@ export const CodeBlock = ({
           {title}
         </CardTitle>
         <Button
+          aria-label="Copy code"
           className={cn("shrink-0", className)}
           onClick={copyToClipboard}
           size="icon"

--- a/components/geistdocs/docs-page.tsx
+++ b/components/geistdocs/docs-page.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 type PageProps = ComponentProps<typeof FumadocsDocsPage>;
 
 export const DocsPage = ({ ...props }: PageProps) => (
-  <FumadocsDocsPage {...props} />
+  <FumadocsDocsPage {...props} role="main" tabIndex={-1} />
 );
 
 export const DocsTitle = ({

--- a/components/geistdocs/docs-page.tsx
+++ b/components/geistdocs/docs-page.tsx
@@ -9,8 +9,13 @@ import { cn } from "@/lib/utils";
 
 type PageProps = ComponentProps<typeof FumadocsDocsPage>;
 
-export const DocsPage = ({ ...props }: PageProps) => (
-  <FumadocsDocsPage {...props} role="main" tabIndex={-1} />
+export const DocsPage = ({ className, ...props }: PageProps) => (
+  <FumadocsDocsPage
+    {...props}
+    className={cn("scroll-mt-[var(--fd-docs-row-3)]", className)}
+    role="main"
+    tabIndex={-1}
+  />
 );
 
 export const DocsTitle = ({

--- a/components/geistdocs/sidebar.tsx
+++ b/components/geistdocs/sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { Node } from "fumadocs-core/page-tree";
+import { usePathname } from "fumadocs-core/framework";
 import {
   SidebarFolder,
   SidebarFolderContent,
@@ -24,6 +25,9 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { SearchButton } from "./search";
+
+const isActive = (href: string, pathname: string) =>
+  href.replace(/\/$/, "") === pathname.replace(/\/$/, "");
 
 export const InheritedSidebarProvider = ({
   children,
@@ -98,12 +102,18 @@ export const Folder: SidebarPageTreeComponents["Folder"] = ({
   item,
 }) => {
   const path = useTreePath();
+  const pathname = usePathname();
   const defaultOpen = item.defaultOpen ?? path.includes(item);
 
   return (
-    <SidebarFolder collapsible={item.collapsible} defaultOpen={defaultOpen}>
+    <SidebarFolder
+      active={path.includes(item)}
+      collapsible={item.collapsible}
+      defaultOpen={defaultOpen}
+    >
       {item.index ? (
         <SidebarFolderLink
+          active={isActive(item.index.url, pathname)}
           className="flex items-center gap-2 text-pretty py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground data-[active=true]:text-foreground [&_svg]:size-3.5"
           external={item.index.external}
           href={item.index.url}
@@ -122,16 +132,21 @@ export const Folder: SidebarPageTreeComponents["Folder"] = ({
   );
 };
 
-export const Item: SidebarPageTreeComponents["Item"] = ({ item }) => (
-  <SidebarItem
-    className="block w-full truncate text-pretty py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground data-[active=true]:text-foreground"
-    external={item.external}
-    href={item.url}
-    icon={item.icon}
-  >
-    {item.name}
-  </SidebarItem>
-);
+export const Item: SidebarPageTreeComponents["Item"] = ({ item }) => {
+  const pathname = usePathname();
+
+  return (
+    <SidebarItem
+      active={isActive(item.url, pathname)}
+      className="block w-full truncate text-pretty py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground data-[active=true]:text-foreground"
+      external={item.external}
+      href={item.url}
+      icon={item.icon}
+    >
+      {item.name}
+    </SidebarItem>
+  );
+};
 
 export const Separator: SidebarPageTreeComponents["Separator"] = ({ item }) => (
   <SidebarSeparator className="mt-4 mb-2 flex items-center gap-2 px-0 font-medium text-sm first-child:mt-0">

--- a/components/geistdocs/sidebar.tsx
+++ b/components/geistdocs/sidebar.tsx
@@ -104,6 +104,9 @@ export const Folder: SidebarPageTreeComponents["Folder"] = ({
   const path = useTreePath();
   const pathname = usePathname();
   const defaultOpen = item.defaultOpen ?? path.includes(item);
+  const indexActive = item.index
+    ? isActive(item.index.url, pathname)
+    : false;
 
   return (
     <SidebarFolder
@@ -113,8 +116,9 @@ export const Folder: SidebarPageTreeComponents["Folder"] = ({
     >
       {item.index ? (
         <SidebarFolderLink
-          active={isActive(item.index.url, pathname)}
-          className="flex items-center gap-2 text-pretty py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground data-[active=true]:text-foreground [&_svg]:size-3.5"
+          active={indexActive}
+          aria-current={indexActive ? "page" : undefined}
+          className="flex items-center gap-2 text-pretty py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground data-[active=true]:font-medium data-[active=true]:text-foreground [&_svg]:size-3.5"
           external={item.index.external}
           href={item.index.url}
         >
@@ -134,11 +138,13 @@ export const Folder: SidebarPageTreeComponents["Folder"] = ({
 
 export const Item: SidebarPageTreeComponents["Item"] = ({ item }) => {
   const pathname = usePathname();
+  const active = isActive(item.url, pathname);
 
   return (
     <SidebarItem
-      active={isActive(item.url, pathname)}
-      className="block w-full truncate text-pretty py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground data-[active=true]:text-foreground"
+      active={active}
+      aria-current={active ? "page" : undefined}
+      className="block w-full truncate text-pretty py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground data-[active=true]:font-medium data-[active=true]:text-foreground"
       external={item.external}
       href={item.url}
       icon={item.icon}

--- a/components/geistdocs/theme-toggle.tsx
+++ b/components/geistdocs/theme-toggle.tsx
@@ -19,7 +19,12 @@ export const ThemeToggle = () => {
 
   if (!mounted) {
     return (
-      <Button size="icon-sm" type="button" variant="ghost">
+      <Button
+        aria-label="Toggle theme"
+        size="icon-sm"
+        type="button"
+        variant="ghost"
+      >
         <div className="size-4" />
       </Button>
     );
@@ -28,7 +33,13 @@ export const ThemeToggle = () => {
   const Icon = resolvedTheme === "dark" ? MoonIcon : SunIcon;
 
   return (
-    <Button onClick={handleClick} size="icon-sm" type="button" variant="ghost">
+    <Button
+      aria-label="Toggle theme"
+      onClick={handleClick}
+      size="icon-sm"
+      type="button"
+      variant="ghost"
+    >
       <Icon className="size-4" />
     </Button>
   );


### PR DESCRIPTION
## Summary

- mark the current page and containing folder active in the documentation sidebar
- add accessible names to theme and code-copy icon buttons
- add a skip link and focusable main content landmark

## Why

The custom sidebar renderer did not forward route state, and several icon-only controls and repeated navigation elements lacked the semantics needed for efficient assistive-technology and keyboard navigation.

## Validation

- `next build`
- rendered `/plugin-authors/skills` assertions for active navigation, accessible button names, skip-link target, and main landmark
