### PR TITLE
Prioritize exact-title documentation search results

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,4 +1,48 @@
 import { createFromSource } from "fumadocs-core/search/server";
 import { source } from "@/lib/geistdocs/source";
 
-export const { GET } = createFromSource(source);
+const search = createFromSource(source);
+type SearchResult = Awaited<ReturnType<typeof search.search>>[number];
+
+const MARK_TAG_PATTERN = /<\/?mark>/g;
+
+const normalize = (value: string) =>
+  value.replace(MARK_TAG_PATTERN, "").trim().toLocaleLowerCase();
+
+const promoteExactTitle = (results: SearchResult[], query: string) => {
+  const start = results.findIndex(
+    (result) =>
+      result.type === "page" && normalize(result.content) === normalize(query)
+  );
+
+  if (start <= 0) {
+    return results;
+  }
+
+  const nextPage = results.findIndex(
+    (result, index) => index > start && result.type === "page"
+  );
+  const end = nextPage === -1 ? results.length : nextPage;
+
+  return [
+    ...results.slice(start, end),
+    ...results.slice(0, start),
+    ...results.slice(end),
+  ];
+};
+
+export const GET = async (request: Request) => {
+  const response = await search.GET(request);
+  const query = new URL(request.url).searchParams.get("query");
+
+  if (!(response.ok && query)) {
+    return response;
+  }
+
+  const results = (await response.json()) as SearchResult[];
+
+  return Response.json(promoteExactTitle(results, query), {
+    headers: response.headers,
+    status: response.status,
+  });
+};


### PR DESCRIPTION
## Summary

- promote an exact page-title match and its result group to the top of documentation search
- preserve the existing Fumadocs ranking for non-exact queries

## Why

Direct navigational searches could place the matching page below several excerpts from broader reference pages.

## Validation

- `next build`
- exact-title search assertions for Skills, Plugin manifest, Client extensions, MCP servers, and Client conformance checklist
- non-exact `manifest` query assertion confirming the existing ranking remains unchanged
