### PR TITLE
Stop inferring sitemap document types

### DIFF
--- a/app/sitemap.md/route.ts
+++ b/app/sitemap.md/route.ts
@@ -69,22 +69,6 @@ function buildTree(
   return root;
 }
 
-function inferDocType(url: string, explicitType?: string): string {
-  if (explicitType) {
-    return explicitType.charAt(0).toUpperCase() + explicitType.slice(1);
-  }
-  if (url.includes("/getting-started")) {
-    return "Guide";
-  }
-  if (url.includes("/reference")) {
-    return "Reference";
-  }
-  if (url.includes("/guides/")) {
-    return "Guide";
-  }
-  return "Conceptual";
-}
-
 function extractTopics(url: string, product?: string): string[] {
   const topics: string[] = [];
   if (product) {
@@ -125,7 +109,10 @@ function renderNode(
   const lines: string[] = [];
 
   const segments: string[] = [];
-  segments.push(`Type: ${inferDocType(node.url, node.type)}`);
+  if (node.type) {
+    const type = node.type.charAt(0).toUpperCase() + node.type.slice(1);
+    segments.push(`Type: ${type}`);
+  }
 
   if (node.lastmod) {
     segments.push(`Lastmod: ${node.lastmod}`);


### PR DESCRIPTION
## Summary

- remove legacy URL-based document-type inference
- omit `Type` from sitemap entries whose pages do not explicitly declare one
- preserve the deliberate `reference` classifications introduced by PR #29

## Why

The semantic sitemap assigned `Conceptual` to every untyped page whose URL did not match one of three legacy patterns. None of the current untyped routes match those patterns, so the sitemap asserted classifications that were absent from the individual machine-readable page metadata.

The specification, schemas, and conformance checklist remain explicitly classified as reference artifacts. Derivative documentation remains unclassified.

## Validation

- `pnpm build`
- production TypeScript validation
- rendered `/sitemap.md` assertions for typed and untyped entries
- conceptual review council
- adversarial code review
