### PR TITLE
Simplify exact-title search ranking

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,48 +1,31 @@
 import { createFromSource } from "fumadocs-core/search/server";
 import { source } from "@/lib/geistdocs/source";
 
-const search = createFromSource(source);
-type SearchResult = Awaited<ReturnType<typeof search.search>>[number];
+const normalizedTitlesByUrl = new Map(
+  source
+    .getPages()
+    .map((page) => [page.url, page.data.title.trim().toLowerCase()])
+);
 
-const MARK_TAG_PATTERN = /<\/?mark>/g;
+export const { GET } = createFromSource(source, {
+  plugins: [
+    {
+      name: "exact-title-first",
+      afterSearch: (_database, params, _language, results) => {
+        const query = params.term?.trim().toLowerCase();
+        const groups = results.groups;
 
-const normalize = (value: string) =>
-  value.replace(MARK_TAG_PATTERN, "").trim().toLocaleLowerCase();
+        // Fumadocs groups advanced-search results by page URL.
+        const index =
+          groups?.findIndex(
+            (group) =>
+              normalizedTitlesByUrl.get(String(group.values[0])) === query
+          ) ?? -1;
 
-const promoteExactTitle = (results: SearchResult[], query: string) => {
-  const start = results.findIndex(
-    (result) =>
-      result.type === "page" && normalize(result.content) === normalize(query)
-  );
-
-  if (start <= 0) {
-    return results;
-  }
-
-  const nextPage = results.findIndex(
-    (result, index) => index > start && result.type === "page"
-  );
-  const end = nextPage === -1 ? results.length : nextPage;
-
-  return [
-    ...results.slice(start, end),
-    ...results.slice(0, start),
-    ...results.slice(end),
-  ];
-};
-
-export const GET = async (request: Request) => {
-  const response = await search.GET(request);
-  const query = new URL(request.url).searchParams.get("query");
-
-  if (!(response.ok && query)) {
-    return response;
-  }
-
-  const results = (await response.json()) as SearchResult[];
-
-  return Response.json(promoteExactTitle(results, query), {
-    headers: response.headers,
-    status: response.status,
-  });
-};
+        if (groups && index > 0) {
+          groups.unshift(...groups.splice(index, 1));
+        }
+      },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

- promote exact-title matches through Orama's `afterSearch` hook
- remove response parsing, highlight stripping, and result-block reconstruction
- document the Fumadocs page-URL grouping invariant

## Why

PR #31 established the desired exact-title behavior with a clear response-level implementation. Now that the behavior is understood and covered by focused validation, it can be expressed closer to the search engine: reordering Fumadocs' grouped result before it is flattened preserves the endpoint behavior, handles small output limits, and reduces the route from 48 lines to 31.

## Validation

- `pnpm build` (44 static pages generated)
- `pnpm exec tsc --noEmit --incremental false`
- exact `Plugin manifest` query returns the manifest page first with `limit=1`
- non-exact `manifest` query retains the native specification-first ordering
- prior adversarial review covered all 12 published titles, result-group contiguity, case and whitespace normalization, empty queries, tags, and duplicate-title behavior
