### PR TITLE
Emphasize sidebar section headings

### DIFF
--- a/components/geistdocs/sidebar.tsx
+++ b/components/geistdocs/sidebar.tsx
@@ -155,7 +155,7 @@ export const Item: SidebarPageTreeComponents["Item"] = ({ item }) => {
 };
 
 export const Separator: SidebarPageTreeComponents["Separator"] = ({ item }) => (
-  <SidebarSeparator className="mt-4 mb-2 flex items-center gap-2 px-0 font-medium text-sm first-child:mt-0">
+  <SidebarSeparator className="mt-4 mb-2 flex items-center gap-2 px-0 font-semibold text-sm first-child:mt-0">
     {item.icon}
     {item.name}
   </SidebarSeparator>


### PR DESCRIPTION
## Summary

- increase documentation sidebar section headings from medium to semibold weight
- preserve the medium-weight treatment for the active page link

## Why

The active-page accessibility update made the selected link medium weight, matching the existing section headings. Giving the divisions a slightly stronger weight restores the intended navigation hierarchy.

## Validation

- reviewed in the local site preview
- `git diff --check`