### PR TITLE
Guide automated site contributions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Instructions
+
+## Source of truth
+
+This site presents the current portable contract defined by the [Agent Plugins specification](https://github.com/agentplugins/agent-plugins-spec); it is not a second specification. Guides may clarify and reorganize that contract, but must not introduce normative behavior or present future considerations as supported features. Changes to the portable contract belong in the specification repository first.
+
+## Documentation approach
+
+Write concise guidance for people encountering Agent Plugins for the first time. Describe the resulting contract rather than the discussion or design history behind it. Prefer linking to one primary explanation over duplicating material. "Plugin Authors" and "Client Implementers" are navigational perspectives, not information silos.
+
+## Published representations
+
+Documentation pages are published as HTML and as machine-readable `.md` and `.mdx`. Treat all three representations as part of the public interface when changing routes, redirects, or links.


### PR DESCRIPTION
## Summary

- establish the Agent Plugins specification as the site's source of truth
- guide agents toward concise, current-contract documentation
- preserve HTML, `.md`, and `.mdx` as public representations when changing routes and links

## Why

These principles were repeatedly relevant during the site rewrite and are easy for an automated contributor to overlook. Recording them keeps future changes aligned without duplicating framework documentation or adding a broad procedural checklist.

## Impact

This adds contributor guidance only. It does not change site content, behavior, or dependencies.

## Validation

- `git diff --check`
- verified the PR contains only the new `AGENTS.md` file
