### PR TITLE
Explain Agent Plugins motivation and openness

### DIFF
--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -3,7 +3,13 @@ title: Agent Plugins
 description: A portable package format for reusable components that extend AI agents.
 ---
 
-Agent Plugins is an open, vendor-neutral specification for packaging reusable components that extend AI agents into distributable plugins. Its portable contract builds on two existing standards: [Agent Skills](https://agentskills.io/specification) and the [Model Context Protocol](https://modelcontextprotocol.io/specification).
+Agent Plugins is an open, vendor-neutral specification for packaging reusable components into portable plugins. Version 1.0 defines a shared format for [Agent Skills](https://agentskills.io/specification) and [MCP servers](https://modelcontextprotocol.io/specification) that compatible clients can discover and load consistently.
+
+## Why Agent Plugins?
+
+AI agent clients have developed their own plugin formats, even when plugins contain the same underlying components. Authors must rearrange or duplicate those components for each client, so a plugin packaged for one client may need adaptation before another can use it.
+
+Agent Plugins defines a small interoperability floor for the parts that can be portable across clients. Shared components can use one predictable structure, while distribution, installation, permissions, user experience, and client-specific capabilities remain under each client's control.
 
 ## The portable package
 
@@ -27,7 +33,13 @@ my-plugin/
 - `mcp.json` describes stdio, Streamable HTTP, or legacy HTTP+SSE MCP servers.
 - Reverse-domain extension namespaces let individual clients add behavior without changing the portable core.
 
-Agent Plugins intentionally leaves distribution, marketplaces, installation workflows, permissions, and client UX outside the portable contract.
+## Open development
+
+Agent Plugins is openly licensed and developed in public. Its initial Technical Steering Committee includes Core Maintainers from Amazon, Cursor, Microsoft, OpenAI, and Vercel.
+
+Proposals and technical decisions are public, and participation is open to the broader ecosystem. Ideas for new features and material changes begin in [GitHub Discussions](https://github.com/agentplugins/agent-plugins-spec/discussions), where proposals can establish a concrete portability need and implementer support.
+
+Explore the specification, schemas, governance, and contribution process in the [Agent Plugins specification repository](https://github.com/agentplugins/agent-plugins-spec).
 
 ## Choose your path
 
@@ -37,7 +49,3 @@ Agent Plugins intentionally leaves distribution, marketplaces, installation work
   <Card title="Read the specification" href="/specification" description="Consult the complete normative specification." />
   <Card title="Browse the schemas" href="/schemas" description="Use the canonical plugin and MCP JSON Schemas." />
 </Cards>
-
-## Source and governance
-
-The versioned specification is authoritative. Project governance, contribution guidance, schemas, and release history live in the [Agent Plugins specification repository](https://github.com/agentplugins/agent-plugins-spec).


### PR DESCRIPTION
## Summary

- Introduce Agent Plugins as a reusable component package format, with the version 1.0 scope stated separately.
- Explain the concrete packaging fragmentation addressed by the portable contract.
- Document the project's public development model, initial multi-vendor Technical Steering Committee, and GitHub Discussions proposal path.
- Retain the existing portable package walkthrough and get-started cards.

## Why

The homepage previously moved directly from a one-sentence definition into the package layout. This revision gives plugin authors and client implementers enough context to decide why the interoperability contract is useful, while keeping current version 1.0 behavior precise and leaving future component types unpromised.

This is a documentation-only change and does not alter the Agent Plugins specification.

## Validation

- `git diff --check`
- `./node_modules/.bin/next build`
