### PR TITLE
Link to the Agent Plugins example

### DIFF
--- a/content/docs/plugin-authors/index.mdx
+++ b/content/docs/plugin-authors/index.mdx
@@ -37,6 +37,8 @@ Greet the user and offer help.
 
 A skills-capable client loads `plugin.json`, discovers the immediate children of `skills/`, and validates each `SKILL.md` against the Agent Skills specification. To add MCP servers, place `mcp.json` at the plugin root using the same Agent Plugins schema version.
 
+For a copyable package with a complete manifest and a real skill, see the [Agent Plugins example](https://github.com/agentplugins/agent-plugins-example).
+
 ## Package boundaries
 
 Files supplied by the package must resolve within the plugin root. Configuration fields defined as plugin-relative paths begin with `./`; symlinks and equivalent filesystem mechanisms must not be used to escape the package.


### PR DESCRIPTION
## Summary

- Link the plugin-author walkthrough to the copyable Agent Plugins example repository.
- Place the link directly after the minimal plugin walkthrough, before package-boundary details.

## Why

Readers who have just completed the inline minimal example now have a clear path to inspect a fuller manifest and a real skill without adding an unrelated link elsewhere in the documentation.

## Impact

Documentation-only. The portable contract and schemas are unchanged.

## Validation

- `git diff --check`
- `pnpm build`
