### PR TITLE
Describe Agent Plugins as an open standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Plugins Site
 
-The documentation site for [Agent Plugins](https://github.com/agentplugins/agent-plugins-spec), an open, vendor-neutral specification for packaging reusable components that extend AI agents into distributable plugins.
+The documentation site for [Agent Plugins](https://github.com/agentplugins/agent-plugins-spec), an open, vendor-neutral standard for packaging reusable components that extend AI agents into distributable plugins.
 
 Documentation is published at [agent-plugins.org](https://agent-plugins.org).
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Agent Plugins
 description: A portable package format for reusable components that extend AI agents.
 ---
 
-Agent Plugins is an open, vendor-neutral specification for packaging reusable components into portable plugins. Version 1.0 defines a shared format for [Agent Skills](https://agentskills.io/specification) and [MCP servers](https://modelcontextprotocol.io/specification) that compatible clients can discover and load consistently.
+Agent Plugins is an open, vendor-neutral standard for packaging reusable components into portable plugins. Its Version 1.0.0 specification defines a shared format for [Agent Skills](https://agentskills.io/specification) and supported [MCP server](https://modelcontextprotocol.io/specification) configurations that compatible clients can discover and load consistently.
 
 ## Why Agent Plugins?
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Agent Plugins
 description: A portable package format for reusable components that extend AI agents.
 ---
 
-Agent Plugins is an open, vendor-neutral standard for packaging reusable components into portable plugins. Its Version 1.0.0 specification defines a shared format for [Agent Skills](https://agentskills.io/specification) and supported [MCP server](https://modelcontextprotocol.io/specification) configurations that compatible clients can discover and load consistently.
+Agent Plugins is an open, vendor-neutral standard for packaging reusable components into portable plugins. Its version 1.0.0 specification defines a shared format for [Agent Skills](https://agentskills.io/specification) and [MCP servers](https://modelcontextprotocol.io/specification) that compatible clients can discover and load consistently.
 
 ## Why Agent Plugins?
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-plugins-site",
-  "description": "Documentation site for the Agent Plugins specification.",
+  "description": "Documentation site for the Agent Plugins standard.",
   "version": "0.0.0",
   "private": true,
   "packageManager": "pnpm@10.34.0",


### PR DESCRIPTION
## Summary

- describe Agent Plugins as an open, vendor-neutral standard on the site homepage and in repository copy
- identify Version 1.0.0 as the concrete specification on the homepage
- align the private package description with the same terminology

## Why

Agent Plugins is the broader open standard, which includes its governance structure. Version 1.0.0 is the versioned specification within that standard. The previous wording conflated the two concepts.

## Impact

This is a terminology-only documentation change. It does not alter the portable contract, routes, schemas, or runtime behavior.

## Validation

- `pnpm build`
