### PR TITLE
fix: include compatible clients in machine-readable docs

### DIFF
--- a/lib/compatible-clients.ts
+++ b/lib/compatible-clients.ts
@@ -120,3 +120,35 @@ export const compatibleClients: readonly CompatibleClient[] = [
     },
   },
 ];
+
+const markdownMcpTransportLabels: Record<McpTransport, string> = {
+  stdio: "stdio",
+  "streamable-http": "Streamable HTTP",
+  sse: "legacy SSE",
+};
+
+export const renderCompatibleClientsMarkdown = (): string =>
+  compatibleClients
+    .map((client) => {
+      const lines = [
+        `## [${client.name}](${client.homepageUrl})`,
+        "",
+        client.description,
+        "",
+        client.supports.skills ? "- Agent Skills" : null,
+        client.supports.mcp
+          ? `- MCP: ${client.supports.mcp.transports
+              .map((transport) => markdownMcpTransportLabels[transport])
+              .join(", ")}`
+          : null,
+        client.instructionsUrl
+          ? `- [Setup instructions](${client.instructionsUrl})`
+          : null,
+        client.sourceUrl ? `- [Source code](${client.sourceUrl})` : null,
+      ];
+
+      return lines
+        .filter((line): line is string => line !== null)
+        .join("\n");
+    })
+    .join("\n\n");

--- a/lib/geistdocs/source.ts
+++ b/lib/geistdocs/source.ts
@@ -2,7 +2,7 @@ import { type InferPageType, loader } from "fumadocs-core/source";
 import { lucideIconsPlugin } from "fumadocs-core/source/lucide-icons";
 import { docs } from "@/.source/server";
 import { basePath } from "@/geistdocs";
-
+import { renderCompatibleClientsMarkdown } from "@/lib/compatible-clients";
 // See https://fumadocs.dev/docs/headless/source-api for more info
 export const source = loader({
   baseUrl: "/",
@@ -31,7 +31,10 @@ export const getLLMText = async (
   page: InferPageType<typeof source>,
   { includeNavigationFooter = true } = {}
 ) => {
-  const processed = await page.data.getText("processed");
+  const processed = (await page.data.getText("processed")).replace(
+  "<CompatibleClients />",
+  renderCompatibleClientsMarkdown()
+);
   const { title, description, product, type, summary, prerequisites, related } =
     page.data;
 


### PR DESCRIPTION
## Problem

The Compatible Clients page renders its data using the
`<CompatibleClients />` React component. As a result, generated Markdown
outputs contained the component tag without the client names, capabilities,
MCP transports, or links.

## Solution

Generate a Markdown representation from the existing `compatibleClients`
source of truth and substitute it when producing machine-readable
documentation.

The interactive HTML page remains unchanged.

## Validation

- Ran `corepack pnpm build` successfully.
- Confirmed the generated Compatible Clients Markdown includes all current
  clients.
- Confirmed `<CompatibleClients />` is absent from the generated Markdown.