### PR TITLE
Reorder docs sidebar actions

### DIFF
--- a/app/(docs)/[[...slug]]/page.tsx
+++ b/app/(docs)/[[...slug]]/page.tsx
@@ -34,10 +34,10 @@ const Page = async ({ params }: PageProps<"/[[...slug]]">) => {
         footer: (
           <div className="my-3 space-y-3">
             <Separator />
-            <EditSource path={page.path} />
             <ScrollTop />
-            <CopyPage text={markdown} />
             <OpenInChat href={page.url} />
+            <CopyPage text={markdown} />
+            <EditSource path={page.path} />
           </div>
         ),
       }}


### PR DESCRIPTION
## Summary

- put the reader-focused sidebar actions first
- place **Open in chat** before **Copy page**
- move **Edit this page on GitHub** to the end

## Verification

- `pnpm exec tsc --noEmit`
- `git diff --check`

---

| Before | After |
| --- | --- |
|  <img width="1112" height="473" alt="image" src="https://github.com/user-attachments/assets/a2973a85-5ceb-4e48-a6ca-f70870dd1e9f" /> | <img width="1112" height="473" alt="image" src="https://github.com/user-attachments/assets/1af40310-ca10-452b-b4b9-10500a006753" /> |

