### PR TITLE
Show platform-aware search shortcut

### DIFF
--- a/components/geistdocs/search.tsx
+++ b/components/geistdocs/search.tsx
@@ -52,7 +52,7 @@ export const SearchDialog = ({
 };
 
 export const SearchButton = ({ className, onClick }: SearchButtonProps) => {
-  const { setOpenSearch } = useSearchContext();
+  const { hotKey, setOpenSearch } = useSearchContext();
 
   return (
     <Button
@@ -69,7 +69,16 @@ export const SearchButton = ({ className, onClick }: SearchButtonProps) => {
       variant="outline"
     >
       <span>Search...</span>
-      <Kbd className="border bg-background font-medium">⌘K</Kbd>
+      <div className="inline-flex gap-0.5">
+        {hotKey.map(({ display }, index) => (
+          <Kbd
+            className="border bg-background font-medium"
+            key={index}
+          >
+            {display}
+          </Kbd>
+        ))}
+      </div>
     </Button>
   );
 };


### PR DESCRIPTION
## Summary

- Render the search shortcut label from the Fumadocs context.
- Display each shortcut part as its own keycap: `Ctrl` and `K` on Windows/Linux, or `⌘` and `K` on Apple platforms.

## Testing

- `pnpm exec tsc --noEmit --incremental false`
- `pnpm exec next build --webpack`