### PR TITLE
Publish Agent Plugins specification status

### DIFF
--- a/content/docs/specification.mdx
+++ b/content/docs/specification.mdx
@@ -6,7 +6,7 @@ type: reference
 
 **Spec Version: 1.0.0**
 
-**Status: Working Draft**
+**Status: Published**
 
 This document defines the canonical Agent Plugins Specification v1.0.0 for packaging reusable components that extend AI agents into distributable plugins.
 

--- a/specification-source.json
+++ b/specification-source.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/agentplugins/agent-plugins-spec",
   "version": "1.0.0",
-  "status": "working-draft",
-  "commit": "b78a4f162d92c4b09ee205a11f59a6187926d947"
+  "status": "published",
+  "commit": "bd383552095128f6effe895b9257cfd580a6d179"
 }


### PR DESCRIPTION
## Summary

- mark the embedded Agent Plugins 1.0.0 specification as Published
- record the current canonical specification revision in `specification-source.json`
- confirm the site JSON schemas already match the canonical 1.0.0 schemas byte-for-byte

## Verification

- `pnpm build`
- verified `/specification`, `/specification.md`, and `/specification.mdx` render the Published status
- compared both served schema files byte-for-byte with their canonical upstream versions