### PR TITLE
Add Discord collaboration link to homepage

### DIFF
--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -37,7 +37,7 @@ my-plugin/
 
 Agent Plugins is openly licensed and developed in public. Its initial Technical Steering Committee includes Core Maintainers from Amazon, Cursor, Microsoft, OpenAI, and Vercel.
 
-Proposals and technical decisions are public, and participation is open to the broader ecosystem. Ideas for new features and material changes begin in [GitHub Discussions](https://github.com/agentplugins/agent-plugins-spec/discussions), where proposals can establish a concrete portability need and implementer support.
+Proposals and technical decisions are public, and participation is open to the broader ecosystem. Use [GitHub Discussions](https://github.com/agentplugins/agent-plugins-spec/discussions) for asynchronous collaboration on ideas for new features and material changes, where proposals can establish a concrete portability need and implementer support. When synchronous collaboration on the standard is useful, join the [Agent Plugins Discord](https://discord.gg/692jE8wsmj).
 
 Explore the specification, schemas, governance, and contribution process in the [Agent Plugins specification repository](https://github.com/agentplugins/agent-plugins-spec).
 


### PR DESCRIPTION
## Summary

- describe GitHub Discussions as the asynchronous collaboration channel
- link the Agent Plugins Discord for synchronous collaboration on the standard

## Validation

- `pnpm exec next build --webpack`